### PR TITLE
fix missing usage of datapath in PASCAL dataset

### DIFF
--- a/data/pascal.py
+++ b/data/pascal.py
@@ -17,8 +17,8 @@ class DatasetPASCAL(Dataset):
         self.benchmark = 'pascal'
         self.shot = shot
 
-        self.img_path = os.path.join('../VOCdevkit/VOC2012/JPEGImages/')
-        self.ann_path = os.path.join('../VOCdevkit/VOC2012/SegmentationClassAug/')
+        self.img_path = os.path.join(datapath, 'VOC2012/JPEGImages/')
+        self.ann_path = os.path.join(datapath, 'VOC2012/SegmentationClassAug/')
         self.transform = transform
 
         self.class_ids = self.build_class_ids()


### PR DESCRIPTION
The original code for `DatasetPASCAL` didn't make use of the `datapath` argument. I changed it to use the provided argument. The default behavior isn't changed by that as the default value for `datapath` in `train.py` is `../VOCdevkit`.